### PR TITLE
GetByQuery に Limit(1) をつける対応

### DIFF
--- a/cloudfirestore/helper.go
+++ b/cloudfirestore/helper.go
@@ -123,6 +123,7 @@ func GetMulti(ctx context.Context, client *firestore.Client, docRefs []*firestor
 
 // GetByQuery ... クエリで単体取得する(tx対応)
 func GetByQuery(ctx context.Context, query firestore.Query, dst interface{}) (bool, error) {
+	query = query.Limit(1)
 	var it *firestore.DocumentIterator
 	if tx := getContextTransaction(ctx); tx != nil {
 		it = tx.Documents(query)


### PR DESCRIPTION
GetByQuery で大量のドキュメントがロックされる可能性があったので、Limit(1)をつけました