### PR TITLE
maputil 実装

### DIFF
--- a/maputil/util.go
+++ b/maputil/util.go
@@ -1,0 +1,200 @@
+package maputil
+
+type empty struct{}
+type set[T comparable] map[T]empty
+type orderedSet[T comparable] map[T]int
+type Map[T comparable, U any] map[T]U
+type JSON map[string]any
+
+// --- Set 関数 ---
+
+func NewSet[T comparable](s []T) set[T] {
+	set := set[T]{}
+	for _, v := range s {
+		set[v] = empty{}
+	}
+	return set
+}
+
+// --- OrderedSet 関数 ---
+
+func NewOrderedSet[T comparable](s []T) orderedSet[T] {
+	set := orderedSet[T]{}
+	for _, v := range s {
+		set.Add(v)
+	}
+	return set
+}
+
+// --- Map 関数 ---
+
+func NewMap[T comparable, U any](m map[T]U) Map[T, U] {
+	return Map[T, U](m)
+}
+
+// Has ... key が存在するかどうか
+func Has[T comparable, U any](m map[T]U, key T) bool {
+	_, ok := m[key]
+	return ok
+}
+
+// Keys ... キーの配列を返す
+func Keys[T comparable, U any](m map[T]U) []T {
+	keys := make([]T, len(m))
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
+// Values ... 値の配列を返す
+func Values[T comparable, U any](m map[T]U) []U {
+	values := make([]U, len(m))
+	i := 0
+	for _, v := range m {
+		values[i] = v
+		i++
+	}
+	return values
+}
+
+// ValuesByKeys ... keys 配列の順番で value の配列を返す(map に存在するもののみ)
+func ValuesByKeys[T comparable, U any](m map[T]U, keys []T) []U {
+	values := []U{}
+	for _, k := range keys {
+		if v, ok := m[k]; ok {
+			values = append(values, v)
+		}
+	}
+	return values
+}
+
+// Clear ... map を空にする
+func Clear[T comparable, U any](m map[T]U) {
+	for k := range m {
+		delete(m, k)
+	}
+}
+
+// --- Set メソッド ---
+
+// Len ... 要素数を返す
+func (s set[T]) Len() int {
+	return len(s)
+}
+
+// Has ... key が存在するかどうか
+func (s set[T]) Has(key T) bool {
+	return Has(s, key)
+}
+
+// Keys ... キーの配列を返す
+func (s set[T]) Keys() []T {
+	return Keys(s)
+}
+
+// Add ... キーを追加する
+func (s set[T]) Add(key T) {
+	s[key] = empty{}
+}
+
+// Delete ... キーを削除する
+func (s set[T]) Delete(key T) {
+	delete(s, key)
+}
+
+// Clear ... Set を空にする
+func (s set[T]) Clear() {
+	Clear(s)
+}
+
+// --- OrderedSet メソッド ---
+
+// Len ... 要素数を返す
+func (s orderedSet[T]) Len() int {
+	return len(s)
+}
+
+// Has ... key が存在するかどうか
+func (s orderedSet[T]) Has(key T) bool {
+	return Has(s, key)
+}
+
+// Keys ... キーの配列を返す
+func (s orderedSet[T]) Keys() []T {
+	keys := make([]T, len(s))
+	for k, v := range s {
+		keys[v] = k
+	}
+	return keys
+}
+
+// Add ... キーを追加する
+func (s orderedSet[T]) Add(key T) {
+	if !s.Has(key) {
+		s[key] = len(s)
+	}
+}
+
+// Delete ... キーを削除する
+func (s orderedSet[T]) Delete(key T) {
+	if i, ok := s[key]; ok {
+		for k, v := range s {
+			if v > i {
+				s[k] = v - 1
+			}
+		}
+		delete(s, key)
+	}
+}
+
+// Clear ... Set を空にする
+func (s orderedSet[T]) Clear() {
+	Clear(s)
+}
+
+// --- Map メソッド ---
+
+// Len ... 要素数を返す
+func (m Map[T, U]) Len() int {
+	return len(m)
+}
+
+// Has ... key が存在するかどうか
+func (m Map[T, U]) Has(key T) bool {
+	return Has(m, key)
+}
+
+// Keys ... キーの配列を返す
+func (m Map[T, U]) Keys() []T {
+	return Keys(m)
+}
+
+// Values ... 値の配列を返す
+func (m Map[T, U]) Values() []U {
+	return Values(m)
+}
+
+// ValuesByKeys ... keys 配列の順番で value の配列を返す(map に存在するもののみ)
+func (m Map[T, U]) ValuesByKeys(keys []T) []U {
+	return ValuesByKeys(m, keys)
+}
+
+// Delete ... キーを削除する
+func (m Map[T, U]) Delete(key T) {
+	delete(m, key)
+}
+
+// Clear ... Map を空にする
+func (m Map[T, U]) Clear() {
+	Clear(m)
+}
+
+// --- JSON メソッド ---
+
+// ToMap ... JSON 型を Map 型に変換する
+func (j JSON) ToMap() Map[string, any] {
+	return Map[string, any](j)
+}

--- a/maputil/util.go
+++ b/maputil/util.go
@@ -8,6 +8,7 @@ type JSON map[string]any
 
 // --- Set 関数 ---
 
+// NewSet ... slice から Set を作成する
 func NewSet[T comparable](s []T) set[T] {
 	set := set[T]{}
 	for _, v := range s {
@@ -18,6 +19,7 @@ func NewSet[T comparable](s []T) set[T] {
 
 // --- OrderedSet 関数 ---
 
+// NewOrderedSet ... slice から orderedSet を作成する。orderedSet は Set と違い Keys() の戻り値が挿入した順になります。そのため、uniqなsliceのような扱い方もできます。
 func NewOrderedSet[T comparable](s []T) orderedSet[T] {
 	set := orderedSet[T]{}
 	for _, v := range s {
@@ -28,6 +30,7 @@ func NewOrderedSet[T comparable](s []T) orderedSet[T] {
 
 // --- Map 関数 ---
 
+// NewMap ... Map を作成する
 func NewMap[T comparable, U any](m map[T]U) Map[T, U] {
 	return Map[T, U](m)
 }
@@ -38,7 +41,7 @@ func Has[T comparable, U any](m map[T]U, key T) bool {
 	return ok
 }
 
-// Keys ... キーの配列を返す
+// Keys ... キーのslice を返す
 func Keys[T comparable, U any](m map[T]U) []T {
 	keys := make([]T, len(m))
 	i := 0
@@ -49,7 +52,7 @@ func Keys[T comparable, U any](m map[T]U) []T {
 	return keys
 }
 
-// Values ... 値の配列を返す
+// Values ... 値のslice を返す
 func Values[T comparable, U any](m map[T]U) []U {
 	values := make([]U, len(m))
 	i := 0
@@ -60,7 +63,7 @@ func Values[T comparable, U any](m map[T]U) []U {
 	return values
 }
 
-// ValuesByKeys ... keys 配列の順番で value の配列を返す(map に存在するもののみ)
+// ValuesByKeys ... keys slice の順番で value のslice を返す(map に存在するもののみ)
 func ValuesByKeys[T comparable, U any](m map[T]U, keys []T) []U {
 	values := []U{}
 	for _, k := range keys {
@@ -90,7 +93,7 @@ func (s set[T]) Has(key T) bool {
 	return Has(s, key)
 }
 
-// Keys ... キーの配列を返す
+// Keys ... キーのslice を返す
 func (s set[T]) Keys() []T {
 	return Keys(s)
 }
@@ -122,7 +125,7 @@ func (s orderedSet[T]) Has(key T) bool {
 	return Has(s, key)
 }
 
-// Keys ... キーの配列を返す
+// Keys ... キーのslice を返す
 func (s orderedSet[T]) Keys() []T {
 	keys := make([]T, len(s))
 	for k, v := range s {
@@ -167,17 +170,17 @@ func (m Map[T, U]) Has(key T) bool {
 	return Has(m, key)
 }
 
-// Keys ... キーの配列を返す
+// Keys ... キーのslice を返す
 func (m Map[T, U]) Keys() []T {
 	return Keys(m)
 }
 
-// Values ... 値の配列を返す
+// Values ... 値のslice を返す
 func (m Map[T, U]) Values() []U {
 	return Values(m)
 }
 
-// ValuesByKeys ... keys 配列の順番で value の配列を返す(map に存在するもののみ)
+// ValuesByKeys ... keys slice の順番で value のslice を返す(map に存在するもののみ)
 func (m Map[T, U]) ValuesByKeys(keys []T) []U {
 	return ValuesByKeys(m, keys)
 }

--- a/maputil/util_test.go
+++ b/maputil/util_test.go
@@ -1,0 +1,165 @@
+package maputil_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rabee-inc/go-pkg/maputil"
+	"gopkg.in/go-playground/assert.v1"
+)
+
+func Test(t *testing.T) {
+
+	// Values, Has, ValuesByKeys
+	t.Run("Values, Has, ValuesByKeys", func(t *testing.T) {
+		m1 := map[string]int{
+			"one":   1,
+			"two":   2,
+			"three": 3,
+		}
+		expected := []int{1, 2, 3}
+		actual := maputil.ValuesByKeys(m1, []string{"one", "two", "three"})
+		fmt.Println("actual:", actual, "expected:", expected)
+		m2 := maputil.Map[string, int]{
+			"one":   1,
+			"two":   2,
+			"three": 3,
+		}
+		assert.Equal(t, m2.Has("one"), true)
+		assert.Equal(t, m2.Has("two"), true)
+		assert.Equal(t, m2.Has("three"), true)
+		assert.Equal(t, m2.Has("four"), false)
+		m3 := maputil.NewMap(m1)
+		m3["five"] = 5
+		m3["four"] = 4
+		ints := m3.ValuesByKeys([]string{"one", "two", "three"})
+		assertSlice(t, ints, []int{1, 2, 3})
+		fmt.Println("values: ", m3.Values())
+	})
+
+	// Keys
+	t.Run("Keys", func(t *testing.T) {
+		m := map[string]int{
+			"one":   1,
+			"two":   2,
+			"three": 3,
+		}
+		set := maputil.NewSet(maputil.Keys(m))
+		assert.Equal(t, set.Has("one"), true)
+		assert.Equal(t, set.Has("two"), true)
+		assert.Equal(t, set.Has("three"), true)
+		assert.Equal(t, set.Len(), 3)
+		m2 := maputil.Map[string, int]{
+			"one": 1,
+		}
+		m2["two"] = 2
+		m2["three"] = 3
+		set = maputil.NewSet(m2.Keys())
+		assert.Equal(t, set.Has("one"), true)
+		assert.Equal(t, set.Has("two"), true)
+		assert.Equal(t, set.Has("three"), true)
+		assert.Equal(t, set.Len(), 3)
+	})
+
+	// Delete
+	t.Run("Delete", func(t *testing.T) {
+		m := maputil.Map[string, int]{
+			"one": 1,
+		}
+		m["two"] = 2
+		m["three"] = 3
+		m.Delete("two")
+		assert.Equal(t, len(m), 2)
+	})
+
+	// Clear
+	t.Run("Clear", func(t *testing.T) {
+		m := map[string]int{
+			"one":   1,
+			"two":   2,
+			"three": 3,
+		}
+		maputil.Clear(m)
+		assert.Equal(t, len(m), 0)
+
+		m2 := maputil.Map[string, int]{
+			"one": 1,
+		}
+		m2.Clear()
+		assert.Equal(t, len(m2), 0)
+	})
+
+	// --- JSON ---
+	t.Run("JSON", func(t *testing.T) {
+		// json := map[string]any{}
+		json := maputil.JSON{
+			"one": 1,
+			"two": "2",
+		}
+		// var m map[string]any = json
+		json["three"] = maputil.Map[string, float64]{
+			"three_one": 3.1,
+		}
+		assert.Equal(t, json.ToMap().Has("one"), true)
+		assert.Equal(t, json["one"], 1)
+		assert.Equal(t, json["two"], "2")
+		assertMap(t, json["three"].(maputil.Map[string, float64]), map[string]float64{"three_one": 3.1})
+	})
+
+	// --- OrderedSet ---
+
+	// Add, Delete, Keys
+	t.Run("Add, Delete, Keys", func(t *testing.T) {
+		s := maputil.NewOrderedSet([]int{0, 1, 2, 3})
+		assertSlice(t, s.Keys(), []int{0, 1, 2, 3})
+
+		s.Add(4)
+		assertSlice(t, s.Keys(), []int{0, 1, 2, 3, 4})
+
+		s.Delete(2)
+		assertSlice(t, s.Keys(), []int{0, 1, 3, 4})
+
+		s.Add(2)
+		assertSlice(t, s.Keys(), []int{0, 1, 3, 4, 2})
+
+		s.Add(1)
+		assertSlice(t, s.Keys(), []int{0, 1, 3, 4, 2})
+	})
+
+}
+
+func assertMap[T comparable, U comparable](t *testing.T, expected, actual map[T]U) {
+	if !eqMap(expected, actual) {
+		t.Errorf("expected: %v, actual: %v", expected, actual)
+	}
+}
+
+func assertSlice[T comparable](t *testing.T, expected, actual []T) {
+	if !eqSlice(expected, actual) {
+		t.Errorf("expected: %v, actual: %v", expected, actual)
+	}
+}
+
+func eqMap[T comparable, U comparable](a, b map[T]U) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if v != b[k] {
+			return false
+		}
+	}
+	return true
+}
+
+func eqSlice[T comparable](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
set, orderedSet, Map, JSON を実装

特筆すべきは **ValuesByKeys** かと思います。

例)
```
itemMap := hoge.GetMulti(itemIDs)
items := maputil.ValuesByKeys(itemMap, itemIDs) // itemIDs 順の items
```

**JSON** は、map[string]any を省略したりあとで Map のメソッドを使いたい場合に使用できます

```
json := maputil.JSON{
  "one": 1,
  "two": 2,
}

json["one"] // 1
json.ToMap().ValuesByKeys([]string{"one", "two"}) // 1, 2

```

詳しくはtestを見てください

