### PR TITLE
add sliceutil.FilterMap

### DIFF
--- a/sliceutil/util.go
+++ b/sliceutil/util.go
@@ -61,6 +61,28 @@ func MapWithIndex[T, E any](srcs []T, fn func(index int) E) Slice[E] {
 	return dsts
 }
 
+// FilterMap ... Filter して Map する
+func FilterMap[T, E any](srcs []T, fn func(src T) (bool, E)) Slice[E] {
+	dsts := []E{}
+	for _, src := range srcs {
+		if ok, dst := fn(src); ok {
+			dsts = append(dsts, dst)
+		}
+	}
+	return dsts
+}
+
+// FilterMapWithIndex ... Filter して Map する
+func FilterMapWithIndex[T, E any](srcs []T, fn func(index int) (bool, E)) Slice[E] {
+	dsts := []E{}
+	for i := range srcs {
+		if ok, dst := fn(i); ok {
+			dsts = append(dsts, dst)
+		}
+	}
+	return dsts
+}
+
 // Reduce ... reduce
 func Reduce[T, E any](srcs []T, fn func(dst E, src T) E) E {
 	var dst E

--- a/sliceutil/util_test.go
+++ b/sliceutil/util_test.go
@@ -350,7 +350,35 @@ func Test(t *testing.T) {
 			assertSlice(t, expect[i], s)
 		}
 	})
+	// Excludes
+	t.Run("Excludes", func(t *testing.T) {
+		// 関数
+		expect := []int{1, 3, 5}
+		input := []int{1, 2, 3, 4, 5}
+		ignore := []int{2, 4}
+		actual := sliceutil.Excludes(input, ignore)
+		assertSlice(t, expect, actual)
+	})
 
+	// FilterMap
+	t.Run("FilterMap", func(t *testing.T) {
+		// 関数
+		expect := []int{1, 3, 5}
+		type num struct {
+			i int
+		}
+		input := []*num{
+			{i: 1},
+			{i: 2},
+			{i: 3},
+			{i: 4},
+			{i: 5},
+		}
+		actual := sliceutil.FilterMap(input, func(n *num) (bool, int) {
+			return n.i%2 == 1, n.i
+		})
+		assertSlice(t, expect, actual)
+	})
 }
 
 func eqSlice[T comparable](a, b []T) bool {

--- a/sliceutil/util_test.go
+++ b/sliceutil/util_test.go
@@ -379,6 +379,27 @@ func Test(t *testing.T) {
 		})
 		assertSlice(t, expect, actual)
 	})
+
+	// FilterMapWithIndex
+	t.Run("FilterMapWithIndex", func(t *testing.T) {
+		// 関数
+		expect := []int{1, 3, 5}
+		type num struct {
+			i int
+		}
+		input := []*num{
+			{i: 1},
+			{i: 2},
+			{i: 3},
+			{i: 4},
+			{i: 5},
+		}
+		actual := sliceutil.FilterMapWithIndex(input, func(i int) (bool, int) {
+			n := input[i]
+			return n.i%2 == 1, n.i
+		})
+		assertSlice(t, expect, actual)
+	})
 }
 
 func eqSlice[T comparable](a, b []T) bool {


### PR DESCRIPTION
SSIA

example

```go

type num struct {
	i int
}
input := []*num{
	{i: 1},
	{i: 2},
	{i: 3},
	{i: 4},
	{i: 5},
}
// filtered: []int{1, 3, 5}
filtered := sliceutil.FilterMap(input, func(n *num) (bool, int) {
	return n.i%2 == 1, n.i
})

filtered2 := sliceutil.FilterMapWithIndex(input, func(i int) (bool, int) {
	n := input[i]
	return n.i%2 == 1, n.i
})

```