### PR TITLE
rapi.TypeScanner で scan される対象にomitempty と validateタグを付与

### DIFF
--- a/rapi/router_impl.go
+++ b/rapi/router_impl.go
@@ -163,7 +163,6 @@ func (r *router) Trace(pattern string, re RouterElement) {
 	r.handle(http.MethodTrace, pattern, re)
 }
 
-// router のエンドポイントと input, output の型定義を出力する
 func (r *router) GetRouterDefinition() ([]*RouterDefinition, map[string]*TypeStructure) {
 	ts := NewTypeScanner()
 	ts.DisableStructField()

--- a/rapi/type_scanner.go
+++ b/rapi/type_scanner.go
@@ -23,7 +23,9 @@ type TypeStructure struct {
 	// map, slice, array の要素の型情報。それ以外は nil
 	ElemType *TypeStructure `json:"elem_type,omitempty"`
 	// struct の field の型情報。それ以外は nil
-	Fields map[string]*TypeStructure `json:"fields,omitempty"`
+	Fields    map[string]*TypeStructure `json:"fields,omitempty"`
+	OmitEmpty bool                      `json:"omit_empty,omitempty"`
+	Validate  string                    `json:"validate,omitempty"`
 }
 
 type UnionStructure struct {


### PR DESCRIPTION
- validate: required じゃなければ任意指定という判定をフロントで行う
- omitemptyならプロパティが存在しない可能性があることをフロントで判定するため
