### PR TITLE
codegen: 同じextends値の場合、mapのように記述できるようにする

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -315,6 +315,95 @@ var ItemMap map[Item]*ItemMetaData
 
 ```
 
+## groups
+
+`groups` を使うと、`extends` で追加したプロパティをまとめて指定することができます。
+
+**入力例**
+
+```yaml
+types:
+  item:
+    comment: アイテム
+    extends:
+      category: string
+    groups:
+      - props:
+          category: animal
+        defs:
+          dog: 犬
+          cat: 猫
+
+      - props:
+          category: plant
+        defs:
+          tomato: トマト
+          potato: ポテト
+
+```
+
+**出力**
+
+```go
+
+// Item ... アイテム
+type Item string
+
+func (c Item) String() string {
+	return string(c)
+}
+
+func (c Item) Meta() (*ItemMetaData, bool) {
+	m, ok := ItemMap[c]
+	return m, ok
+}
+
+func (c Item) Name() string {
+	if m, ok := c.Meta(); ok {
+		return m.Name
+	}
+	return ""
+}
+
+const (
+	ItemDog    Item = "dog"
+	ItemCat    Item = "cat"
+	ItemTomato Item = "tomato"
+	ItemPotato Item = "potato"
+)
+
+type ItemMetaData struct {
+	ID       Item   `json:"id"`
+	Name     string `json:"name"`
+	Category string `json:"category"`
+}
+
+var Items = []*ItemMetaData{
+	{
+		ID:       ItemDog,
+		Name:     "犬",
+		Category: "animal",
+	},
+	{
+		ID:       ItemCat,
+		Name:     "猫",
+		Category: "animal",
+	},
+	{
+		ID:       ItemTomato,
+		Name:     "トマト",
+		Category: "plant",
+	},
+	{
+		ID:       ItemPotato,
+		Name:     "ポテト",
+		Category: "plant",
+	},
+}
+
+var ItemMap map[Item]*ItemMetaData
+
+```
 
 ## templates > extends_defs
 

--- a/codegen/codemodel.go
+++ b/codegen/codemodel.go
@@ -99,8 +99,34 @@ func newTypeDef(ts *typeInput, extendsDefMap map[string]*extendsDef) *typeDef {
 		td.Extends = extendsDef
 	}
 
+	// Groups
+	inputDefs := ts.Defs
+	for _, group := range ts.Groups {
+		for _, def := range group.Defs {
+			// 新しい defInput を作る
+			inputDef := &defInput{
+				Name:    def.Name,
+				PropMap: defPropInputMap{},
+			}
+
+			for k, v := range group.PropMap {
+				inputDef.PropMap[k] = v
+			}
+
+			for k, v := range def.PropMap {
+				// check duplicate
+				if _, ok := group.PropMap[k]; ok {
+					panic(fmt.Sprintf("%s > groups (%s) invalid def: %s is duplicate.", typeName, def.Name, k))
+				}
+				inputDef.PropMap[k] = v
+			}
+
+			inputDefs = append(inputDefs, inputDef)
+		}
+	}
+
 	// Defs
-	for _, def := range ts.Defs {
+	for _, def := range inputDefs {
 		variableName := def.Name
 		it := &typeDefsItem{
 			VariableName:  variableName,

--- a/codegen/input.go
+++ b/codegen/input.go
@@ -26,14 +26,20 @@ type templatesInput struct {
 	ExtendsDefs extendsDefInputList `yaml:"extends_defs"`
 }
 
+type groupInput struct {
+	PropMap defPropInputMap `yaml:"props" validate:"required"`
+	Defs    defInputList    `yaml:"defs" validate:"required"`
+}
+
 // typeInput ... types のそれぞれを構造化したもの
 type typeInput struct {
 	Name        string
-	Comment     string       `yaml:"comment" validate:"required"`
-	Type        string       `yaml:"type"`
-	OnlyBackend bool         `yaml:"only_backend"`
-	Extends     extendsInput `yaml:"extends"`
-	Defs        defInputList `yaml:"defs" validate:"required"`
+	Comment     string        `yaml:"comment" validate:"required"`
+	Type        string        `yaml:"type"`
+	OnlyBackend bool          `yaml:"only_backend"`
+	Extends     extendsInput  `yaml:"extends"`
+	Defs        defInputList  `yaml:"defs"`
+	Groups      []*groupInput `yaml:"groups"`
 }
 
 // typeInputList ... types を構造化したもの

--- a/codegen/test/const2/const2.go
+++ b/codegen/test/const2/const2.go
@@ -2,7 +2,7 @@
 
 package const2
 
-const CheckSum = "27a51e9211da89fdc2a4717efc93bb5d94ade4d638815b77facf51bcda100f5f"
+const CheckSum = "a4667c33fb7c7def44dc07ba38ee20306cbe549785b4ee79bc820061059b3730"
 
 type ConstantMetaData[T comparable] struct {
 	ID   T      `json:"id"`
@@ -293,6 +293,7 @@ func (c ExtendsDefsTestA) Name() string {
 
 const (
 	ExtendsDefsTestAV1 ExtendsDefsTestA = "v1"
+	ExtendsDefsTestAV2 ExtendsDefsTestA = "v2"
 )
 
 type ExtendsDefsTestAMetaData WithCategoryMetaData[ExtendsDefsTestA]
@@ -302,6 +303,13 @@ var ExtendsDefsTestAs = []*ExtendsDefsTestAMetaData{
 		ID: ExtendsDefsTestAV1,
 		WithCategoryMetaDataProps: &WithCategoryMetaDataProps{
 			Name:     "v1",
+			Category: CategoryFood,
+		},
+	},
+	{
+		ID: ExtendsDefsTestAV2,
+		WithCategoryMetaDataProps: &WithCategoryMetaDataProps{
+			Name:     "v2",
 			Category: CategoryFood,
 		},
 	},

--- a/codegen/test/defs/const2.yaml
+++ b/codegen/test/defs/const2.yaml
@@ -22,6 +22,7 @@ types:
       blue:
         id: 2
         name: 青
+
   baby:
     comment: "test: -y to -ies"
     defs:
@@ -58,14 +59,20 @@ types:
       v1:
         name: v1
         category: food
+    groups:
+      - props:
+          category: food
+        defs:
+          v2: v2
 
   extends_defs_test_b:
     comment: test extends defs
     extends: with_category
-    defs:
-      v1:
-        name: v1
-        category: bag
+    groups:
+      - props:
+          category: bag
+        defs:
+          v1: v1
 
   player:
     comment: プレイヤー


### PR DESCRIPTION
groupsに対応。
対応内容は [こちら](https://github.com/rabee-inc/go-pkg/blob/e35ad6ddade8776a032af15799ce86a9f9f63ab6/codegen/README.md#groups) を参照。

#42 がマージされたらマージ予定