### PR TITLE
FirebaseAuthのモジュールを、SwaggerUIに対応

### DIFF
--- a/firebaseauth/service_debug.go
+++ b/firebaseauth/service_debug.go
@@ -22,7 +22,7 @@ func NewServiceDebug(cFirebaseAuth *auth.Client, dummyClaims map[string]any) Ser
 // 認証を行う
 func (s *serviceDebug) Authentication(ctx context.Context, ah string) (string, map[string]any, error) {
 	// AuthorizationHeaderからUserが取得できたらデバッグリクエストと判定する
-	if user := getUserByAuthHeader(ah); user != "" {
+	if user := getDebugByAuthHeader(ah); user != "" {
 		return user, s.dummyClaims, nil
 	}
 	return s.sFirebaseAuth.Authentication(ctx, ah)
@@ -32,7 +32,7 @@ func (s *serviceDebug) Authentication(ctx context.Context, ah string) (string, m
 func (s *serviceDebug) SetCustomClaims(ctx context.Context, userID string, claims map[string]any) error {
 	// AuthorizationHeaderからUserが取得できたらデバッグリクエストと判定する
 	ah := getAuthHeader(ctx)
-	if getUserByAuthHeader(ah) != "" {
+	if getDebugByAuthHeader(ah) != "" {
 		return nil
 	}
 	return s.sFirebaseAuth.SetCustomClaims(ctx, userID, claims)

--- a/firebaseauth/util.go
+++ b/firebaseauth/util.go
@@ -1,6 +1,7 @@
 package firebaseauth
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -17,9 +18,11 @@ func getTokenByAuthHeader(ah string) string {
 	return ""
 }
 
-func getUserByAuthHeader(ah string) string {
-	if strings.HasPrefix(ah, debugHeaderPrefix) {
-		return ah[len(debugHeaderPrefix):]
+func getDebugByAuthHeader(ah string) string {
+	token := getTokenByAuthHeader(ah)
+	fmt.Printf("token: %s\n", token)
+	if strings.HasPrefix(token, debugHeaderPrefix) {
+		return token[len(debugHeaderPrefix):]
 	}
 	return ""
 }


### PR DESCRIPTION
- 世間に浸透している open api に対応したい
- しかし、swagger ui は Bearer が authorization に勝手についてしまう
- 本番運用は上記で問題ないが、デバッグのユーザー認証だとだめ
- デバッグのユーザー認証も Bearer をつけて `Bearer use=FirebaseAuthUID`という形にする