### PR TITLE
fix: ConvertibleBatchGetter.Get(id) で取得できていないものがゼロ値で取得できてしまう不具合の修正

### DIFF
--- a/cloudfirestore/convertible_batch_getter_impl.go
+++ b/cloudfirestore/convertible_batch_getter_impl.go
@@ -114,7 +114,11 @@ func (cbg *convertibleBatchGetter[S, D]) convertAll() {
 		}
 		item.RemoveAfter()
 		item.RemoveOnEmpty()
-		cbg.DstMap[item.Path] = item.Dst
+		if src == nil {
+			cbg.DstMap[item.Path] = nil
+		} else {
+			cbg.DstMap[item.Path] = item.Dst
+		}
 		item.Converted = true
 	}
 }


### PR DESCRIPTION
SSIA