### PR TITLE
[Firestore] タグ指定で親のIDをmodelに設定できる様に対応

### DIFF
--- a/cloudfirestore/util.go
+++ b/cloudfirestore/util.go
@@ -21,7 +21,7 @@ func SetDocByDst(dst any, ref *firestore.DocumentRef) {
 				rv.Field(i).Set(reflect.ValueOf(ref))
 				continue
 			}
-			if tag == "parent" && f.Type.Kind() == reflect.Ptr {
+			if tag == "parent_id" && f.Type.Kind() == reflect.Ptr {
 				rv.Field(i).Set(reflect.ValueOf(ref.Parent.Parent.ID))
 				continue
 			}
@@ -42,7 +42,7 @@ func SetDocByDsts(rv reflect.Value, rt reflect.Type, ref *firestore.DocumentRef)
 				rv.Elem().Field(i).Set(reflect.ValueOf(ref))
 				continue
 			}
-			if tag == "parent" && f.Type.Kind() == reflect.Ptr {
+			if tag == "parent_id" && f.Type.Kind() == reflect.Ptr {
 				rv.Elem().Field(i).Set(reflect.ValueOf(ref.Parent.Parent.ID))
 				continue
 			}

--- a/cloudfirestore/util.go
+++ b/cloudfirestore/util.go
@@ -21,6 +21,10 @@ func SetDocByDst(dst any, ref *firestore.DocumentRef) {
 				rv.Field(i).Set(reflect.ValueOf(ref))
 				continue
 			}
+			if tag == "parent" && f.Type.Kind() == reflect.Ptr {
+				rv.Field(i).Set(reflect.ValueOf(ref.Parent.Parent.ID))
+				continue
+			}
 		}
 	}
 }
@@ -36,6 +40,10 @@ func SetDocByDsts(rv reflect.Value, rt reflect.Type, ref *firestore.DocumentRef)
 			}
 			if tag == "ref" && f.Type.Kind() == reflect.Ptr {
 				rv.Elem().Field(i).Set(reflect.ValueOf(ref))
+				continue
+			}
+			if tag == "parent" && f.Type.Kind() == reflect.Ptr {
+				rv.Elem().Field(i).Set(reflect.ValueOf(ref.Parent.Parent.ID))
 				continue
 			}
 		}


### PR DESCRIPTION
# やりたいこと
Firestore で SubCollection を使っている時に、取得した model の中に親 Collection の ID が入っていると便利だなと思うことが多いので、タグで取れるようにしてみた。

# 悩み
データ設計によっては「親の親の親」がほしいとかありそうなので、タグ名が単に「parent」だとなんか微妙感がある。
かといって「parent1」とか「parent2」とかにするのも微妙なので、何かアイディアがあればほしい