### PR TITLE
fix: [codegen] only_backend のときも Map を生成する

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -196,13 +196,13 @@ func GenerateByYamlFile(name string, file []byte) ([]byte, *yamlInput) {
 		// meta data map (var)
 		outputCode += formatConstantMetaDataMap(toPascalCase(td.Name))
 
+		// init map generate codes (only_backend でも Map は生成する)
+		generateMapCodes = append(generateMapCodes, formatGenerateMapCode(pascalName))
+
 		if !td.OnlyBackend {
 			// constant struct params
 			constantsStructParams = append(constantsStructParams, formatConstantsStructParam(toPluralForm(td.Name), formatConstantMetaDataListTypeName(pascalName)))
 			constantsStructParams = append(constantsStructParams, formatConstantsStructParam(td.Name, formatConstantMetaDataMapTypeName(pascalName)))
-
-			// init map generate codes
-			generateMapCodes = append(generateMapCodes, formatGenerateMapCode(pascalName))
 
 			// generate any slice for GetConstIDs
 			anySliceVarName := strings.ToLower(pascalName[0:1]) + pascalName[1:]

--- a/codegen/test/const1/const1.go
+++ b/codegen/test/const1/const1.go
@@ -35,7 +35,9 @@ const (
 
 type AnimalMetaData ConstantMetaData[Animal]
 
-var Animals = []*AnimalMetaData{
+type AnimalMetaDataList []*AnimalMetaData
+
+var Animals = AnimalMetaDataList{
 	{
 		ID:   AnimalDog,
 		Name: "犬",
@@ -84,7 +86,9 @@ type ExtendsTestMetaData struct {
 	StringSliceValue []string    `json:"string_slice_value"`
 }
 
-var ExtendsTests = []*ExtendsTestMetaData{
+type ExtendsTestMetaDataList []*ExtendsTestMetaData
+
+var ExtendsTests = ExtendsTestMetaDataList{
 	{
 		ID:               ExtendsTestV1,
 		Name:             "value test 1",
@@ -131,7 +135,9 @@ type TypeTestMetaData struct {
 	ExtendsTest ExtendsTest `json:"extends_test"`
 }
 
-var TypeTests = []*TypeTestMetaData{
+type TypeTestMetaDataList []*TypeTestMetaData
+
+var TypeTests = TypeTestMetaDataList{
 	{
 		ID:          TypeTestV1,
 		Name:        "test",
@@ -143,11 +149,11 @@ var TypeTests = []*TypeTestMetaData{
 var TypeTestMap map[TypeTest]*TypeTestMetaData
 
 type Constants struct {
-	Animals      []*AnimalMetaData                    `json:"animals"`
+	Animals      AnimalMetaDataList                   `json:"animals"`
 	Animal       map[Animal]*AnimalMetaData           `json:"animal"`
-	ExtendsTests []*ExtendsTestMetaData               `json:"extends_tests"`
+	ExtendsTests ExtendsTestMetaDataList              `json:"extends_tests"`
 	ExtendsTest  map[ExtendsTest]*ExtendsTestMetaData `json:"extends_test"`
-	TypeTests    []*TypeTestMetaData                  `json:"type_tests"`
+	TypeTests    TypeTestMetaDataList                 `json:"type_tests"`
 	TypeTest     map[TypeTest]*TypeTestMetaData       `json:"type_test"`
 }
 

--- a/codegen/test/const2/const2.go
+++ b/codegen/test/const2/const2.go
@@ -14,7 +14,7 @@ type WithCategoryMetaDataProps struct {
 	Category Category `json:"category"`
 }
 
-type WithCategoryMetaData[T WithCategory] struct {
+type WithCategoryMetaData[T comparable] struct {
 	ID T `json:"id"`
 	*WithCategoryMetaDataProps
 }
@@ -31,7 +31,7 @@ type CharacterStatusMetaDataProps struct {
 	Skills []Skill `json:"skills"`
 }
 
-type CharacterStatusMetaData[T CharacterStatus] struct {
+type CharacterStatusMetaData[T comparable] struct {
 	ID T `json:"id"`
 	*CharacterStatusMetaDataProps
 }
@@ -62,7 +62,9 @@ const (
 
 type ColorMetaData ConstantMetaData[Color]
 
-var Colors = []*ColorMetaData{
+type ColorMetaDataList []*ColorMetaData
+
+var Colors = ColorMetaDataList{
 	{
 		ID:   ColorRed,
 		Name: "赤",
@@ -100,7 +102,9 @@ const (
 
 type BabyMetaData ConstantMetaData[Baby]
 
-var Babies = []*BabyMetaData{
+type BabyMetaDataList []*BabyMetaData
+
+var Babies = BabyMetaDataList{
 	{
 		ID:   BabyV1,
 		Name: "v1",
@@ -134,7 +138,9 @@ const (
 
 type ToyMetaData ConstantMetaData[Toy]
 
-var Toys = []*ToyMetaData{
+type ToyMetaDataList []*ToyMetaData
+
+var Toys = ToyMetaDataList{
 	{
 		ID:   ToyV1,
 		Name: "v1",
@@ -168,7 +174,9 @@ const (
 
 type OsMetaData ConstantMetaData[Os]
 
-var Oses = []*OsMetaData{
+type OsMetaDataList []*OsMetaData
+
+var Oses = OsMetaDataList{
 	{
 		ID:   OsV1,
 		Name: "v1",
@@ -204,7 +212,9 @@ const (
 
 type SkillMetaData ConstantMetaData[Skill]
 
-var Skills = []*SkillMetaData{
+type SkillMetaDataList []*SkillMetaData
+
+var Skills = SkillMetaDataList{
 	{
 		ID:   SkillMagicGuard,
 		Name: "魔法無効",
@@ -248,7 +258,9 @@ const (
 
 type CategoryMetaData ConstantMetaData[Category]
 
-var Categories = []*CategoryMetaData{
+type CategoryMetaDataList []*CategoryMetaData
+
+var Categories = CategoryMetaDataList{
 	{
 		ID:   CategoryFood,
 		Name: "フード",
@@ -298,7 +310,28 @@ const (
 
 type ExtendsDefsTestAMetaData WithCategoryMetaData[ExtendsDefsTestA]
 
-var ExtendsDefsTestAs = []*ExtendsDefsTestAMetaData{
+type ExtendsDefsTestAMetaDataList []*ExtendsDefsTestAMetaData
+
+func (l ExtendsDefsTestAMetaDataList) PrimitiveList() []*WithCategoryMetaData[string] {
+	r := []*WithCategoryMetaData[string]{}
+	for _, v := range l {
+		r = append(r, &WithCategoryMetaData[string]{
+			ID:                        string(v.ID),
+			WithCategoryMetaDataProps: v.WithCategoryMetaDataProps,
+		})
+	}
+	return r
+}
+
+func (l ExtendsDefsTestAMetaDataList) PrimitiveMap() map[string]*WithCategoryMetaData[string] {
+	res := map[string]*WithCategoryMetaData[string]{}
+	for _, v := range l.PrimitiveList() {
+		res[v.ID] = v
+	}
+	return res
+}
+
+var ExtendsDefsTestAs = ExtendsDefsTestAMetaDataList{
 	{
 		ID: ExtendsDefsTestAV1,
 		WithCategoryMetaDataProps: &WithCategoryMetaDataProps{
@@ -349,7 +382,28 @@ const (
 
 type ExtendsDefsTestBMetaData WithCategoryMetaData[ExtendsDefsTestB]
 
-var ExtendsDefsTestBs = []*ExtendsDefsTestBMetaData{
+type ExtendsDefsTestBMetaDataList []*ExtendsDefsTestBMetaData
+
+func (l ExtendsDefsTestBMetaDataList) PrimitiveList() []*WithCategoryMetaData[string] {
+	r := []*WithCategoryMetaData[string]{}
+	for _, v := range l {
+		r = append(r, &WithCategoryMetaData[string]{
+			ID:                        string(v.ID),
+			WithCategoryMetaDataProps: v.WithCategoryMetaDataProps,
+		})
+	}
+	return r
+}
+
+func (l ExtendsDefsTestBMetaDataList) PrimitiveMap() map[string]*WithCategoryMetaData[string] {
+	res := map[string]*WithCategoryMetaData[string]{}
+	for _, v := range l.PrimitiveList() {
+		res[v.ID] = v
+	}
+	return res
+}
+
+var ExtendsDefsTestBs = ExtendsDefsTestBMetaDataList{
 	{
 		ID: ExtendsDefsTestBV1,
 		WithCategoryMetaDataProps: &WithCategoryMetaDataProps{
@@ -393,7 +447,28 @@ const (
 
 type PlayerMetaData CharacterStatusMetaData[Player]
 
-var Players = []*PlayerMetaData{
+type PlayerMetaDataList []*PlayerMetaData
+
+func (l PlayerMetaDataList) PrimitiveList() []*CharacterStatusMetaData[string] {
+	r := []*CharacterStatusMetaData[string]{}
+	for _, v := range l {
+		r = append(r, &CharacterStatusMetaData[string]{
+			ID:                           string(v.ID),
+			CharacterStatusMetaDataProps: v.CharacterStatusMetaDataProps,
+		})
+	}
+	return r
+}
+
+func (l PlayerMetaDataList) PrimitiveMap() map[string]*CharacterStatusMetaData[string] {
+	res := map[string]*CharacterStatusMetaData[string]{}
+	for _, v := range l.PrimitiveList() {
+		res[v.ID] = v
+	}
+	return res
+}
+
+var Players = PlayerMetaDataList{
 	{
 		ID: PlayerMagician,
 		CharacterStatusMetaDataProps: &CharacterStatusMetaDataProps{
@@ -441,7 +516,28 @@ const (
 
 type EnemyMetaData CharacterStatusMetaData[Enemy]
 
-var Enemies = []*EnemyMetaData{
+type EnemyMetaDataList []*EnemyMetaData
+
+func (l EnemyMetaDataList) PrimitiveList() []*CharacterStatusMetaData[string] {
+	r := []*CharacterStatusMetaData[string]{}
+	for _, v := range l {
+		r = append(r, &CharacterStatusMetaData[string]{
+			ID:                           string(v.ID),
+			CharacterStatusMetaDataProps: v.CharacterStatusMetaDataProps,
+		})
+	}
+	return r
+}
+
+func (l EnemyMetaDataList) PrimitiveMap() map[string]*CharacterStatusMetaData[string] {
+	res := map[string]*CharacterStatusMetaData[string]{}
+	for _, v := range l.PrimitiveList() {
+		res[v.ID] = v
+	}
+	return res
+}
+
+var Enemies = EnemyMetaDataList{
 	{
 		ID: EnemyWolf,
 		CharacterStatusMetaDataProps: &CharacterStatusMetaDataProps{
@@ -467,23 +563,23 @@ var Enemies = []*EnemyMetaData{
 var EnemyMap map[Enemy]*EnemyMetaData
 
 type Constants struct {
-	Babies            []*BabyMetaData                                `json:"babies"`
+	Babies            BabyMetaDataList                               `json:"babies"`
 	Baby              map[Baby]*BabyMetaData                         `json:"baby"`
-	Toys              []*ToyMetaData                                 `json:"toys"`
+	Toys              ToyMetaDataList                                `json:"toys"`
 	Toy               map[Toy]*ToyMetaData                           `json:"toy"`
-	Oses              []*OsMetaData                                  `json:"oses"`
+	Oses              OsMetaDataList                                 `json:"oses"`
 	Os                map[Os]*OsMetaData                             `json:"os"`
-	Skills            []*SkillMetaData                               `json:"skills"`
+	Skills            SkillMetaDataList                              `json:"skills"`
 	Skill             map[Skill]*SkillMetaData                       `json:"skill"`
-	Categories        []*CategoryMetaData                            `json:"categories"`
+	Categories        CategoryMetaDataList                           `json:"categories"`
 	Category          map[Category]*CategoryMetaData                 `json:"category"`
-	ExtendsDefsTestAs []*ExtendsDefsTestAMetaData                    `json:"extends_defs_test_as"`
+	ExtendsDefsTestAs ExtendsDefsTestAMetaDataList                   `json:"extends_defs_test_as"`
 	ExtendsDefsTestA  map[ExtendsDefsTestA]*ExtendsDefsTestAMetaData `json:"extends_defs_test_a"`
-	ExtendsDefsTestBs []*ExtendsDefsTestBMetaData                    `json:"extends_defs_test_bs"`
+	ExtendsDefsTestBs ExtendsDefsTestBMetaDataList                   `json:"extends_defs_test_bs"`
 	ExtendsDefsTestB  map[ExtendsDefsTestB]*ExtendsDefsTestBMetaData `json:"extends_defs_test_b"`
-	Players           []*PlayerMetaData                              `json:"players"`
+	Players           PlayerMetaDataList                             `json:"players"`
 	Player            map[Player]*PlayerMetaData                     `json:"player"`
-	Enemies           []*EnemyMetaData                               `json:"enemies"`
+	Enemies           EnemyMetaDataList                              `json:"enemies"`
 	Enemy             map[Enemy]*EnemyMetaData                       `json:"enemy"`
 }
 
@@ -555,6 +651,11 @@ func (c *Constants) ConstIDs() [][]any {
 }
 
 func init() {
+
+	ColorMap = map[Color]*ColorMetaData{}
+	for _, v := range Colors {
+		ColorMap[v.ID] = v
+	}
 
 	BabyMap = map[Baby]*BabyMetaData{}
 	for _, v := range Babies {


### PR DESCRIPTION
## Summary
- `only_backend: true` を指定した型で、Map変数の宣言はあるが `init()` 内で populate されないバグを修正
- Map 生成コードを `!td.OnlyBackend` ブロックの外に出し、Constants struct / GetConstIDs / Constants init からの除外は維持

## Test plan
- [x] `codegen/test/` で `go run .` を実行し、`only_backend` の `Color` 型について以下を確認
  - [x] `var ColorMap` が宣言されている
  - [x] `init()` で `ColorMap` が populate される(修正前は欠落していた)
  - [x] `Constants` struct には `Color` / `Colors` が含まれない
  - [x] `GetConstIDs()` の戻り値に color のスライスが含まれない
- [x] `go build ./codegen/test/const2/` でビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)